### PR TITLE
Added lib64 to pkgconfig path to fix issue with aom.pc location

### DIFF
--- a/ffmpeg-nvenc-build.sh
+++ b/ffmpeg-nvenc-build.sh
@@ -225,7 +225,7 @@ compileFfmpeg(){
     Clone https://github.com/FFmpeg/FFmpeg -b master
 
     export PATH="$CUDA_DIR/bin:$PATH"  # ..path to nvcc
-    PKG_CONFIG_PATH="$DEST_DIR/lib/pkgconfig" \
+    PKG_CONFIG_PATH="$DEST_DIR/lib/pkgconfig:$DEST_DIR/lib64/pkgconfig" \
     ./configure \
       --pkg-config-flags="--static" \
       --prefix="$DEST_DIR" \


### PR DESCRIPTION
libaom seems to put the aom.pc in lib64/pkgconfig instead of lib/pkgconfig, causing the build to fail.  Fixed this by adding to the PKG_CONFIG_PATH.